### PR TITLE
build(deps): update JUnit to 5.13.0 and refactor test dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,14 +27,17 @@ java {
 }
 
 dependencies {
+    testImplementation(platform(libs.junit.bom))
+    yamlRestTestRuntimeOnly(platform(libs.junit.bom))
     compileOnly("org.elasticsearch:elasticsearch:${elasticVersion}")
     implementation(libs.velocity)
-    yamlRestTestRuntimeOnly(libs.junit.jupiter.api)
+    yamlRestTestRuntimeOnly("org.junit.jupiter:junit-jupiter-api")
     yamlRestTestRuntimeOnly(libs.hamcrest)
     yamlRestTestRuntimeOnly(libs.log4j)
-    testImplementation(libs.junit.jupiter.api)
-    testImplementation(libs.junit.jupiter.params)
-    testRuntimeOnly(libs.junit.jupiter.engine)
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     jmh(libs.jmh.core)
     jmh(libs.jmh.generator.annprocess)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 velocity = "2.4.1"
-junit = "5.11.4"
+junit = "5.13.0"
 hamcrest = "3.0"
 log4j = "2.24.3"
 jmh = "1.37"
@@ -9,9 +9,7 @@ jmh = "1.37"
 
 [libraries]
 velocity = { module = "org.apache.velocity:velocity-engine-core", version.ref = "velocity" }
-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
-junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 log4j = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }


### PR DESCRIPTION
- Update JUnit version to 5.13.0
- Refactor test dependencies to use JUnit BOM (Bill of Materials)
- Update build.gradle.kts to use new JUnit BOM
- Update gradle/libs.versions.toml to include JUnit BOM and remove individual JUnit modules

